### PR TITLE
Add ARM native build

### DIFF
--- a/src/RegionToShare/app.manifest
+++ b/src/RegionToShare/app.manifest
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1" xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
   <assemblyIdentity version="1.0.0.0" name="MyApplication.app"/>
   <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
     <security>
@@ -25,4 +25,9 @@
     </windowsSettings>
   </application>
 
+  <asmv3:application>
+    <asmv3:windowsSettings xmlns="http://schemas.microsoft.com/SMI/2024/WindowsSettings">
+      <supportedArchitectures>amd64 arm64</supportedArchitectures>
+    </asmv3:windowsSettings>
+  </asmv3:application>
 </assembly>


### PR DESCRIPTION
This PR adds support for building x64 and arm64 explicitly.

![image](https://github.com/user-attachments/assets/8c204ea3-5f74-44c9-a1b3-e7c057c980b3)

The *.appxbundle should contain both *.exe. I was not able to install the bundle due to 'This app package’s publisher certificate could not be verified. ...' even though I add the certificate to my trust store.

The *.appxbundle was create within visual studio. I do not know if the azure pipeline builds correctly though.

Issue https://github.com/tom-englert/RegionToShare/issues/80